### PR TITLE
Use Path::Tiny->slurp instead of File::Slurp::slurp.

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -7,3 +7,6 @@ copyright_holder = Advanced Micro Devices, Inc.
 [@TAPPER]
 dist = Tapper-Cmd
 repository_at = github
+
+[Prereqs]
+Path::Tiny = 0

--- a/lib/Tapper/Cmd.pm
+++ b/lib/Tapper/Cmd.pm
@@ -6,7 +6,7 @@ use Moose;
 extends 'Tapper::Base';
 
 use Tapper::Model 'model';
-use File::Slurp;
+use Path::Tiny;
 
 has schema => (
         is      => 'rw',
@@ -79,7 +79,7 @@ sub apply_macro
         my ($self, $file, $substitutes, $includes) = @_;
 
         $substitutes ||= {};
-        my $plan = File::Slurp::slurp($file);
+        my $plan = path($file)->slurp;
 
         my @include_paths = (Tapper::Config->subconfig->{paths}{testplan_path});
         push @include_paths, @{$includes || [] };

--- a/lib/Tapper/Cmd/Init.pm
+++ b/lib/Tapper/Cmd/Init.pm
@@ -11,8 +11,8 @@ use Tapper::Config;
 use Tapper::Model 'model';
 use File::ShareDir 'module_file', 'module_dir';
 use File::Copy::Recursive 'dircopy';
-use File::Slurp 'slurp';
 use DBI;
+use Path::Tiny;
 
 extends 'Tapper::Cmd';
 
@@ -45,7 +45,7 @@ sub mint_file {
         if (-e $file) {
                 say "SKIP    $file - already exists";
         } else {
-                my $content = slurp module_file('Tapper::Cmd::Init', $basename);
+                my $content = path(module_file('Tapper::Cmd::Init', $basename))->slurp;
                 $content =~ s/__HOME__/$HOME/g;
                 $content =~ s/__USER__/$USER/g;
                 open my $INITCFG, ">", $file or die "Can not create file $file.\n";

--- a/lib/Tapper/Cmd/Testplan.pm
+++ b/lib/Tapper/Cmd/Testplan.pm
@@ -8,7 +8,6 @@ use Try::Tiny;
 use YAML::Syck;
 use Tapper::Model 'model';
 use Tapper::Reports::DPath::TT;
-use File::Slurp 'slurp';
 use Perl6::Junction 'any';
 
 extends 'Tapper::Cmd';


### PR DESCRIPTION
File::Slurp::slurp() -- an alias for File::Slurp::read_file() -- has
dependencies on the core sysread function.  Certain uses of that
function have been deprecated and will become fatal errors with
perl-5.30.  File::Slurp has not yet been modified to avoid those fatal
errors.

Path::Tiny is a well maintained module and its slurp() method can
usually be used as a drop-in replacement for File::Slurp::slurp.